### PR TITLE
Fix: Correct WebUI paths for static files and index.html

### DIFF
--- a/src/utils/webUI.js
+++ b/src/utils/webUI.js
@@ -17,7 +17,7 @@ const configPath = './config/config.json'; // Define configPath once
 
 export async function startServer() {
     // Serve static files from web_public first
-    app.use(express.static(path.resolve('src/web_public')));
+    app.use(express.static(path.resolve('../src/web_public')));
     // Serve static pictures from top-level 'pictures' directory
     app.use('/pictures', express.static(path.resolve('pictures')));
 
@@ -26,7 +26,7 @@ export async function startServer() {
 
     // Root route serves the main HTML file
     app.get("/", (req, res) => {
-        res.sendFile(path.resolve('src/web_public/index.html'));
+        res.sendFile(path.resolve('../src/web_public/index.html'));
     });
 
     // API endpoint to provide initial data for the client-side script


### PR DESCRIPTION
The WebUI was failing to load due to incorrect path resolution. This was likely caused by the application being started from the `src` directory, leading to `path.resolve('src/web_public')` resolving to `src/src/web_public`.

I've corrected the paths in `src/utils/webUI.js` by changing them from `src/web_public` to `../src/web_public`. This ensures that the paths are always resolved correctly from the project root, regardless of the application's starting directory.