### PR TITLE
Fix: Add settings section to config file

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,5 +1,9 @@
 {
-  "debuggingEnv": true,
+  "settings": {
+    "debuggingEnv": true,
+    "tumblrBlogName": "",
+    "discordChannelName": ""
+  },
   "slots": [
     {
       "hour": 9,


### PR DESCRIPTION
The scheduler expects a "settings" section in the configuration file with `debuggingEnv`, `tumblrBlogName`, and `discordChannelName` fields.

This change moves `debuggingEnv` into a new `settings` object and adds `tumblrBlogName` and `discordChannelName` with default empty string values to resolve the configuration error.