### PR TITLE
Fix: Picture preview in WebUI now refreshes on new image

### DIFF
--- a/src/utils/refreshPic.js
+++ b/src/utils/refreshPic.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import pg from 'pg';
 import logger from './logger.js';
+import { refreshData } from './webUI.js';
 const { Client } = pg;
 import { pgConfig } from "../config/credentials.js";
 
@@ -61,6 +62,7 @@ async function extractImage(categories) {
 
     //Save the picture as a file
     fs.writeFileSync(filePath, picture.picture_data);
+    refreshData({ "type": "new_picture", "timestamp": new Date().getTime() });
 
     logger(`Image with ID ${picture.id} saved to ${filePath}`, 'INFO');
   } catch (error) {

--- a/src/web_public/script.js
+++ b/src/web_public/script.js
@@ -79,7 +79,18 @@ document.addEventListener('DOMContentLoaded', () => {
     // SSE for logs
     const eventSource = new EventSource('/events');
     eventSource.onmessage = event => {
-        appendLog(event.data);
+        try {
+            const data = JSON.parse(event.data);
+            if (data && data.type === "new_picture") {
+                displayLatestPicture();
+            } else {
+                // If it's not a new_picture event, treat it as a log message
+                appendLog(event.data);
+            }
+        } catch (e) {
+            // If parsing fails, assume it's a plain text log message
+            appendLog(event.data);
+        }
     };
     eventSource.onerror = error => {
         console.error('SSE error:', error);


### PR DESCRIPTION
The picture preview in the WebUI was not updating when a new picture was generated by the backend.

This commit addresses the issue by:
1. Modifying `refreshPic.js` to send a Server-Sent Event (SSE) of type 'new_picture' after successfully saving a new image.
2. Updating the client-side `script.js` to listen for this 'new_picture' SSE event. Upon receiving the event, the `displayLatestPicture()` function is called to refresh the image preview with the latest `temp_img.jpg`.

This ensures that your WebUI picture preview stays synchronized with the latest generated picture without requiring a manual page reload.