### PR TITLE
feat: Implement UI adjustments including dark mode and responsive layout

### DIFF
--- a/src/web_public/index.html
+++ b/src/web_public/index.html
@@ -7,17 +7,30 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>WebUI</h1>
+    <h1>WebUI
+        <label class="switch">
+            <input type="checkbox" id="darkModeToggle">
+            <span class="slider round"></span>
+        </label>
+    </h1>
 
-    <div id="picture-section">
-        <h2>Latest Picture</h2>
-        <img id="latest-picture" src="" alt="Latest Picture" style="max-width: 500px; display: none;">
-        <p id="no-picture-message">No picture available yet.</p>
-    </div>
+    <div id="top-content-wrapper">
+        <div id="logs-section">
+            <h2>Logs</h2>
+            <div id="log-level-toggles">
+                <label><input type="checkbox" id="log-debug" value="DEBUG"> Debug</label>
+                <label><input type="checkbox" id="log-info" value="INFO" checked> Info</label>
+                <label><input type="checkbox" id="log-warn" value="WARN" checked> Warning</label>
+                <label><input type="checkbox" id="log-error" value="ERROR" checked> Error</label>
+            </div>
+            <div id="logs-container"></div>
+        </div>
 
-    <div id="logs-section">
-        <h2>Logs</h2>
-        <div id="logs-container"></div>
+        <div id="picture-section">
+            <h2>Latest Picture</h2>
+            <img id="latest-picture" src="" alt="Latest Picture" style="max-width: 500px; display: none;">
+            <p id="no-picture-message">No picture available yet.</p>
+        </div>
     </div>
 
     <div id="slots-section">

--- a/src/web_public/script.js
+++ b/src/web_public/script.js
@@ -15,7 +15,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const discordChannelNameInput = document.getElementById('discordChannelName');
     const saveSettingsBtn = document.getElementById('save-settings-btn');
 
+    // Log Level Toggles
+    const logLevelToggles = {
+        DEBUG: document.getElementById('log-debug'),
+        INFO: document.getElementById('log-info'),
+        WARN: document.getElementById('log-warn'),
+        ERROR: document.getElementById('log-error')
+    };
+
     let currentSlots = [];
+    let allLogs = []; // Stores all log messages
 
     // Function to display the latest picture
     function displayLatestPicture() {
@@ -49,7 +58,8 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(data => {
             currentSlots = data.slots || [];
             renderSlots();
-            data.initialMessages.forEach(log => appendLog(log));
+            allLogs = data.initialMessages || []; // Store initial logs
+            renderFilteredLogs(); // Render logs based on default toggle states
             // displayLatestPicture(); // Called at the end of DOMContentLoaded instead
         })
         .catch(error => console.error('Error fetching initial data:', error));
@@ -79,19 +89,62 @@ document.addEventListener('DOMContentLoaded', () => {
     // SSE for logs
     const eventSource = new EventSource('/events');
     eventSource.onmessage = event => {
-        appendLog(event.data);
+        const newLog = event.data;
+        allLogs.push(newLog); // Add to the master list
+        appendLog(newLog); // Append if it matches current filters
     };
     eventSource.onerror = error => {
         console.error('SSE error:', error);
-        appendLog('Error connecting to real-time log updates.');
+        const errorLog = "ERROR: Error connecting to real-time log updates.";
+        allLogs.push(errorLog);
+        appendLog(errorLog);
     };
 
-    function appendLog(message) {
-        const logEntry = document.createElement('div');
-        logEntry.textContent = message; // Server sends plain text, no need to escape here for textContent
-        logsContainer.appendChild(logEntry);
+    // Parses log level from message string. Expects "LEVEL: message"
+    function parseLogLevel(message) {
+        const parts = message.match(/^([A-Z]+):/);
+        if (parts && parts.length > 1) {
+            const level = parts[1].toUpperCase();
+            if (['DEBUG', 'INFO', 'WARN', 'ERROR'].includes(level)) {
+                return level;
+            }
+        }
+        return 'INFO'; // Default level if parsing fails or level is unknown
+    }
+
+    function renderFilteredLogs() {
+        logsContainer.innerHTML = ''; // Clear existing logs
+        allLogs.forEach(message => {
+            const level = parseLogLevel(message);
+            if (logLevelToggles[level] && logLevelToggles[level].checked) {
+                const logEntry = document.createElement('div');
+                logEntry.textContent = message;
+                logEntry.classList.add(`log-${level.toLowerCase()}`); // Optional: for level-specific styling
+                logsContainer.appendChild(logEntry);
+            }
+        });
         logsContainer.scrollTop = logsContainer.scrollHeight; // Scroll to bottom
     }
+
+    // This function now only appends a single log if it passes the filter
+    // It's mainly called by the SSE handler for new incoming logs.
+    function appendLog(message) {
+        const level = parseLogLevel(message);
+        if (logLevelToggles[level] && logLevelToggles[level].checked) {
+            const logEntry = document.createElement('div');
+            logEntry.textContent = message;
+            logEntry.classList.add(`log-${level.toLowerCase()}`);
+            logsContainer.appendChild(logEntry);
+            logsContainer.scrollTop = logsContainer.scrollHeight;
+        }
+    }
+
+    // Add event listeners to log level toggles
+    Object.values(logLevelToggles).forEach(toggle => {
+        if (toggle) { // Ensure toggle element exists
+            toggle.addEventListener('change', renderFilteredLogs);
+        }
+    });
 
     function renderSlots() {
         slotsContainer.innerHTML = ''; // Clear existing slots
@@ -360,6 +413,46 @@ document.addEventListener('DOMContentLoaded', () => {
     // Potentially set an interval if the image is expected to change dynamically
     // and you want the UI to refresh it without a full page reload.
     // setInterval(displayLatestPicture, 60000); // Refresh every 60 seconds, for example
+
+    // Dark Mode Toggle Functionality
+    const darkModeToggle = document.getElementById('darkModeToggle');
+
+    function enableDarkMode() {
+        document.body.classList.add('dark-mode');
+        localStorage.setItem('darkMode', 'enabled');
+        if (darkModeToggle) darkModeToggle.checked = true;
+    }
+
+    function disableDarkMode() {
+        document.body.classList.remove('dark-mode');
+        localStorage.setItem('darkMode', 'disabled');
+        if (darkModeToggle) darkModeToggle.checked = false;
+    }
+
+    // Check localStorage for dark mode preference
+    // Default to dark mode if no preference is set
+    if (localStorage.getItem('darkMode') === 'disabled') {
+        disableDarkMode();
+    } else {
+        enableDarkMode(); // Default to dark mode
+    }
+    // Apply default log toggle states (already set in HTML, but good to be explicit if needed)
+    // logLevelToggles.DEBUG.checked = false;
+    // logLevelToggles.INFO.checked = true;
+    // logLevelToggles.WARN.checked = true;
+    // logLevelToggles.ERROR.checked = true;
+    // renderFilteredLogs(); // Initial render based on defaults - already called after fetching initial data
+
+
+    if (darkModeToggle) {
+        darkModeToggle.addEventListener('change', () => {
+            if (darkModeToggle.checked) {
+                enableDarkMode();
+            } else {
+                disableDarkMode();
+            }
+        });
+    }
 });
 
 // Example helper: function findInitialPicture(slots) { // This helper is no longer used

--- a/src/web_public/style.css
+++ b/src/web_public/style.css
@@ -9,12 +9,48 @@ h1, h2, h3 {
     color: #333;
 }
 
-#picture-section, #logs-section, #slots-section {
+#top-content-wrapper {
+    display: flex;
+    flex-wrap: wrap; /* Allows items to wrap to the next line on smaller screens */
+    gap: 20px; /* Adds space between flex items */
+    margin-bottom: 20px;
+}
+
+#logs-section {
+    flex: 1; /* Allows the logs section to grow and shrink */
+    min-width: 300px; /* Minimum width before wrapping */
+    /* order: 1; /* Explicitly first, though default by source order */
+}
+
+#picture-section {
+    flex: 1; /* Allows the picture section to grow and shrink */
+    min-width: 300px; /* Minimum width before wrapping */
+    /* order: 2; /* Explicitly second, though default by source order */
+}
+
+#picture-section, #logs-section, #slots-section, #global-settings-section {
     background-color: #fff;
     padding: 15px;
     margin-bottom: 20px;
     border-radius: 5px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#log-level-toggles {
+    margin-bottom: 10px;
+    padding: 5px;
+    background-color: #f0f0f0;
+    border-radius: 4px;
+}
+
+#log-level-toggles label {
+    margin-right: 15px;
+    cursor: pointer;
+}
+
+#log-level-toggles input[type="checkbox"] {
+    margin-right: 5px;
+    vertical-align: middle;
 }
 
 #logs-container {
@@ -133,4 +169,151 @@ button:hover, input[type="button"]:hover {
 #slot-modal input[type="checkbox"] {
     margin-top: 10px;
     margin-left: 5px;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #333;
+    color: #f4f4f4;
+}
+
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3 {
+    color: #f4f4f4;
+}
+
+body.dark-mode #picture-section,
+body.dark-mode #logs-section,
+body.dark-mode #slots-section,
+body.dark-mode #global-settings-section,
+body.dark-mode .slot-summary {
+    background-color: #444;
+    box-shadow: 0 2px 4px rgba(255,255,255,0.1);
+}
+
+body.dark-mode #logs-container {
+    background-color: #555;
+    border: 1px solid #666;
+}
+
+body.dark-mode #log-level-toggles {
+    background-color: #3a3a3a;
+}
+
+body.dark-mode #logs-container div {
+    border-bottom: 1px dotted #777;
+}
+
+body.dark-mode button,
+body.dark-mode input[type="button"] {
+    background-color: #0056b3;
+    color: #f4f4f4;
+}
+
+body.dark-mode button:hover,
+body.dark-mode input[type="button"]:hover {
+    background-color: #007bff;
+}
+
+body.dark-mode .delete-slot-btn {
+    background-color: #c82333;
+}
+body.dark-mode .delete-slot-btn:hover {
+    background-color: #dc3545;
+}
+
+body.dark-mode .modal-content {
+    background-color: #555;
+    border: 1px solid #777;
+}
+
+body.dark-mode #slot-modal input[type="text"],
+body.dark-mode #slot-modal input[type="number"],
+body.dark-mode #slot-modal textarea {
+    background-color: #666;
+    color: #f4f4f4;
+    border: 1px solid #888;
+}
+
+
+/* Toggle Switch Styles */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+    float: right;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+input:checked + .slider {
+    background-color: #2196F3;
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+}
+
+.slider.round {
+    border-radius: 34px;
+}
+
+.slider.round:before {
+    border-radius: 50%;
+}
+
+/* Media Query for smaller screens */
+@media (max-width: 768px) { /* Adjust breakpoint as needed */
+    #top-content-wrapper {
+        flex-direction: column;
+    }
+
+    #logs-section, #picture-section {
+        width: 100%; /* Full width for stacked items */
+        margin-bottom: 20px; /* Add margin between stacked items */
+    }
+
+    #logs-section {
+        order: 1; /* Logs section first */
+    }
+
+    #picture-section {
+        order: 2; /* Picture section second */
+    }
 }


### PR DESCRIPTION
This commit introduces several UI enhancements:

1.  **Dark Mode:**
    - Added a toggle switch to enable/disable dark mode.
    - Dark mode is the default theme.
    - Your preference for dark mode is saved in localStorage.
    - Styles updated for body, text, backgrounds, sections, cards, buttons, and modals in dark mode.

2.  **Dynamic Tiles UI (Logs & Picture):**
    - Logs and Preview Picture sections are now responsive.
    - On desktop screens (width > 768px), logs are displayed on the left and the picture on the right, each taking up half the available width.
    - On smaller screens (width <= 768px), these sections stack vertically.

3.  **Log Level Toggles:**
    - Added toggles (checkboxes) for Debug, Info, Warning, and Error log levels in the Logs section.
    - You can now filter displayed logs by level.
    - Debug log level is disabled by default.
    - All incoming logs are stored, and the display is updated dynamically when filter toggles are changed.
    - Assumes log messages from the server are prefixed with their level (e.g., "DEBUG: message text").

4.  **Global Settings UI Restyle:**
    - The Global Settings section is now styled as a card, consistent with the design of other UI elements like Logs, Picture, and Configuration Slots.
    - This includes appropriate styling for both light and dark modes.