### PR TITLE
Fix: Ensure log data is stringified before adding to recentLogs

### DIFF
--- a/src/utils/refreshPic.js
+++ b/src/utils/refreshPic.js
@@ -61,7 +61,7 @@ async function extractImage(categories) {
 
     //Save the picture as a file
     fs.writeFileSync(filePath, picture.picture_data);
-    refreshData({ "type": "new_picture", "timestamp": new Date().getTime() });
+    refreshData(JSON.stringify({ "type": "new_picture", "timestamp": new Date().getTime() }));
 
     logger('INFO', `Image with ID ${picture.id} saved to ${filePath}`);
   } catch (error) {


### PR DESCRIPTION
The webUI.js component was encountering a TypeError (log.replace is not a function) when processing the recentLogs array. This was due to the refreshPic.js module calling refreshData with an object payload ({type: "new_picture", ...}) instead of a string.

This commit fixes the issue by modifying refreshPic.js to stringify the payload using JSON.stringify() before passing it to refreshData. This ensures that all elements pushed to the recentLogs array via refreshData are strings, aligning with the expectations of downstream processing in webUI.js and the logger module.