### PR TITLE
Refactor: Use CSS Grid for top content layout and fix height issues

### DIFF
--- a/src/web_public/index.html
+++ b/src/web_public/index.html
@@ -28,7 +28,7 @@
 
         <div id="picture-section">
             <h2>Latest Picture</h2>
-            <img id="latest-picture" src="" alt="Latest Picture" style="max-width: 500px; display: none;">
+            <img id="latest-picture" src="" alt="Latest Picture">
             <p id="no-picture-message">No picture available yet.</p>
         </div>
     </div>
@@ -43,12 +43,27 @@
 
     <div id="global-settings-section">
         <h2>Global Settings</h2>
-        <label for="debuggingEnv">Debugging Environment:</label>
-        <input type="checkbox" id="debuggingEnv"><br>
-        <label for="tumblrBlogName">Tumblr Blog Name:</label>
-        <input type="text" id="tumblrBlogName" size="30"><br>
-        <label for="discordChannelName">Discord Channel Name:</label>
-        <input type="text" id="discordChannelName" size="30"><br>
+        <div class="setting-item">
+            <label for="debuggingEnv">Debugging Environment:</label>
+            <input type="checkbox" id="debuggingEnv">
+        </div>
+        <div class="setting-item">
+            <label for="tumblrBlogName">Tumblr Blog Name:</label>
+            <input type="text" id="tumblrBlogName">
+        </div>
+        <div class="setting-item">
+            <label for="discordChannelName">Discord Channel Name:</label>
+            <input type="text" id="discordChannelName">
+        </div>
+        <div class="setting-item">
+            <label for="logLevel">Log Level:</label>
+            <select id="logLevel">
+                <option value="DEBUG">Debug</option>
+                <option value="INFO">Info</option>
+                <option value="WARN">Warning</option>
+                <option value="ERROR">Error</option>
+            </select>
+        </div>
         <button id="save-settings-btn">Save Global Settings</button>
     </div>
 

--- a/src/web_public/style.css
+++ b/src/web_public/style.css
@@ -10,22 +10,26 @@ h1, h2, h3 {
 }
 
 #top-content-wrapper {
-    display: flex;
-    flex-wrap: wrap; /* Allows items to wrap to the next line on smaller screens */
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 20px; /* Adds space between flex items */
     margin-bottom: 20px;
 }
 
 #logs-section {
-    flex: 1; /* Allows the logs section to grow and shrink */
+    /* flex: 1; Removed */
     min-width: 300px; /* Minimum width before wrapping */
     /* order: 1; /* Explicitly first, though default by source order */
+    display: flex; /* Existing internal flex layout */
+    flex-direction: column; /* Existing internal flex layout */
+    min-height: 0; /* Added */
 }
 
 #picture-section {
-    flex: 1; /* Allows the picture section to grow and shrink */
+    /* flex: 1; Removed */
     min-width: 300px; /* Minimum width before wrapping */
     /* order: 2; /* Explicitly second, though default by source order */
+    min-height: 0; /* Added */
 }
 
 #picture-section, #logs-section, #slots-section, #global-settings-section {
@@ -54,11 +58,13 @@ h1, h2, h3 {
 }
 
 #logs-container {
-    height: 200px;
-    overflow-y: scroll;
-    border: 1px solid #ddd;
-    padding: 10px;
-    background-color: #e9e9e9;
+    min-height: 200px; /* Changed from height: 200px */
+    overflow-y: scroll; /* Existing */
+    border: 1px solid #ddd; /* Existing */
+    padding: 10px; /* Existing */
+    background-color: #e9e9e9; /* Existing */
+    flex-grow: 1; /* Added */
+    height: 0;            /* Added */
 }
 
 #logs-container div {
@@ -301,12 +307,14 @@ input:checked + .slider:before {
 /* Media Query for smaller screens */
 @media (max-width: 768px) { /* Adjust breakpoint as needed */
     #top-content-wrapper {
+        display: flex; /* Ensure flex behavior on mobile */
         flex-direction: column;
     }
 
-    #logs-section, #picture-section {
+    #logs-section, #picture-section, #slots-section, #global-settings-section {
         width: 100%; /* Full width for stacked items */
         margin-bottom: 20px; /* Add margin between stacked items */
+        box-sizing: border-box; /* Include padding and border in the element's total width and height */
     }
 
     #logs-section {
@@ -316,4 +324,57 @@ input:checked + .slider:before {
     #picture-section {
         order: 2; /* Picture section second */
     }
+
+    #latest-picture {
+        max-width: 100%; /* Ensures image scales down within its container on mobile */
+    }
+}
+
+#latest-picture {
+    width: 100%; /* Changed from max-width: 500px */
+    height: auto; /* Added to maintain aspect ratio */
+    display: block; /* Added for better layout control, will be overridden by script if no image */
+    margin-left: auto; /* For centering if block */
+    margin-right: auto; /* For centering if block */
+}
+
+/* Styles for Global Settings Section */
+#global-settings-section .setting-item {
+    margin-bottom: 15px; /* Space between setting items */
+    display: flex; /* Align label and input on the same line */
+    align-items: center; /* Vertically align items in the flex container */
+    flex-wrap: wrap; /* Allow items to wrap on small screens if necessary */
+}
+
+#global-settings-section .setting-item label {
+    margin-right: 10px; /* Space between label and input */
+    flex-basis: 200px; /* Give label a consistent width */
+    flex-shrink: 0; /* Prevent label from shrinking */
+}
+
+#global-settings-section .setting-item input[type="text"],
+#global-settings-section .setting-item select {
+    flex-grow: 1; /* Allow input/select to take remaining space */
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+    min-width: 200px; /* Minimum width for inputs/select */
+}
+
+#global-settings-section .setting-item input[type="checkbox"] {
+    /* Using default browser styling for checkbox, can be enhanced later if needed */
+    /* margin-left: 0; ensure it aligns well if a specific layout is chosen */
+}
+
+#global-settings-section #save-settings-btn {
+     margin-top: 10px;
+}
+
+/* Dark mode considerations for select element (ensure it's comprehensive) */
+body.dark-mode #global-settings-section .setting-item input[type="text"],
+body.dark-mode #global-settings-section .setting-item select {
+    background-color: #666;
+    color: #f4f4f4;
+    border: 1px solid #888;
 }


### PR DESCRIPTION
This commit refactors the `#top-content-wrapper` to use CSS Grid for its desktop layout, addressing issues where the logs tile could improperly dictate the height of the picture tile.

Key changes:
- `#top-content-wrapper` now uses `display: grid` with two equal columns (`grid-template-columns: 1fr 1fr`) for desktop view. The row height is set to `auto`, determined by the content. Mobile view remains a single stacked column.
- `#picture-section`'s height is now determined by the intrinsic height of the image it contains.
- `#logs-section` now matches the height of `#picture-section` as a fellow grid item in the same row.
- Internal layout of `#logs-section` (using flexbox) ensures that `#logs-container` fills the available height provided by the `#logs-section` tile.
- `#logs-container` uses `height: 0; flex-grow: 1; min-height: 200px;` and `overflow-y: scroll` to correctly fill space and scroll when its content exceeds the allocated height.
- Grid items (`#logs-section`, `#picture-section`) have `min-height: 0` for robust sizing within the grid.

This ensures that the picture's dimensions control the height of its tile, the logs tile matches this height, and the logs container within its tile scrolls as intended without forcing an excessive height on the entire row.